### PR TITLE
resource extension discovery

### DIFF
--- a/source/RazorWare.GfxCore.Domain/Extensibility/PackageManifest.cs
+++ b/source/RazorWare.GfxCore.Domain/Extensibility/PackageManifest.cs
@@ -1,6 +1,9 @@
 
 using System.IO.Compression;
 using System.Reflection;
+using System.Text.Json;
+
+using RazorWare.GfxCore.Events;
 using RazorWare.GfxCore.Registries;
 
 namespace RazorWare.GfxCore.Extensibility;
@@ -10,8 +13,11 @@ namespace RazorWare.GfxCore.Extensibility;
 /// </summary>
 public class PackageManifest
 {
+    private static IEventPipeline Events { get; set; }
+
     private readonly Manifest _manifest;
-    private readonly List<ZipArchiveEntry> _entries = new();
+
+    private List<ZipArchiveEntry> PkgEntries { get; init; } = new();
 
     /// <summary>
     /// Get the extension info for the package.
@@ -21,46 +27,186 @@ public class PackageManifest
     /// Determine if the package has errors.
     /// </summary>
     public bool HasErrors { get; private set; }
+    /// <summary>
+    /// Get the extension assembly name
+    /// </summary>
+    public AssemblyName ExtAssembly => _manifest.Assembly.Name;
 
     /// <summary>
     /// Construct a new package manifest.
     /// </summary>
     /// <param name="manifest">The manifest for the package.</param>
     /// <param name="entries">The entries in the package.</param>
-    public PackageManifest(Manifest manifest, IEnumerable<ZipArchiveEntry> entries)
+    private PackageManifest(Manifest manifest)
     {
         _manifest = manifest;
-        _entries.AddRange(entries);
+    }
+
+    /// <summary>
+    /// Open the package and extract the manifest.
+    /// </summary>
+    /// <param name="pkgFile">The package file to open.</param>
+    /// <param name="pkgManifest">The package manifest.</param>
+    /// <returns>TRUE if the package was opened successfully, otherwise FALSE.</returns>
+    public static bool Unpack(RegistryManager registries, FileInfo pkgFile, out PackageManifest pkgManifest)
+    {
+        var registry = registries.Resolve<ICommandTargetRegistry>();
+        Events = registry.Resolve<IEventPipeline>();
+
+        //  obtain the package file stream
+        using var fs = pkgFile.OpenRead();
+        //  open the package archive
+        using var archive = new ZipArchive(fs, ZipArchiveMode.Read, false);
+        //  open and validate the package
+        if (OpenPackage(out pkgManifest, archive) && pkgManifest.ValidateAssemblies())
+        {
+            var assemblies = registries.Resolve<IAssemblyRegistry>();
+            //  register the extension assembly
+            pkgManifest.RegisterExtensionAssembly(assemblies);
+            //  register the dependency assemblies
+            pkgManifest.RegisterDependencyAssemblies(assemblies);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// open and extract the package contents
+    /// </summary>
+    /// <returns>TRUE if the package was opened successfully, otherwise FALSE.</returns>
+    private static bool OpenPackage(out PackageManifest pkgManifest, ZipArchive archive)
+    {
+        //  find the manifest file ("gfxpackage.json")
+        var manifest_entry = archive.GetEntry(Manifest.PACKAGE_JSON);
+        if (manifest_entry == null)
+        {
+            Log($"{"",13}Invalid Package :: Manifest Not Found");
+            pkgManifest = null;
+            return false;
+        }
+        //  deserialize the manifest file
+        Manifest manifest = JsonSerializer.Deserialize<Manifest>(manifest_entry.Open());
+        if (manifest == null)
+        {
+            Log($"{"",13}Invalid Package :: Manifest Invalid");
+            pkgManifest = null;
+            return false;
+        }
+        //  create the package manifest
+        //  exclude the manifest file from the entries
+        pkgManifest = new PackageManifest(manifest);
+        pkgManifest.PkgEntries.AddRange(archive.Entries.Where(e => e.FullName != Manifest.PACKAGE_JSON));
+
+        return true;
+    }
+
+    private static void Log(string message)
+    {
+        Events.Raise(new LogEvent(message));
     }
 
     /// <summary>
     /// Validate the assemblies in the package.
     /// </summary>
-    /// <exception cref="NotImplementedException"></exception>
-    public void ValidateAssemblies(IAssemblyRegistry assemblies)
+    /// <returns>TRUE if the assemblies are valid, otherwise FALSE.</returns>
+    private bool ValidateAssemblies()
     {
-        var extAssembly = _manifest.Assembly;
-        //  validate dependency assemblies first
-        foreach (var entry in _entries.Where(a => a.FullName != extAssembly.Name.FullName && a.FullName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)))
+        /*      
+                What do we do to validate the manifest assemblies?
+                We are not loading them here, we are just validating them
+                1. iterate dependencies and make sure the zip archive entry exists
+                2. make sure the extension zip archive entry exists
+
+                We check these by looking at the AssemblyInfo objects in the manifest
+         */
+        var ext = _manifest.Assembly;
+        var deps = _manifest.Dependencies;
+
+        //  check if the extension assembly and dependencies are in the package
+        //  TODO: add logging for missing dependencies and add error conditions
+        return PkgEntries.Any(e => e.FullName == ext.EntryTag) &&
+            deps.All(d => PkgEntries.Any(e => e.FullName == d.EntryTag));
+    }
+    /// <summary>
+    /// Register the dependency assemblies.
+    /// </summary>
+    private void RegisterDependencyAssemblies(IAssemblyRegistry assemblies)
+    {
+        Assembly assembly = null;
+        var ext = _manifest.Assembly;
+        var extDependencies = _manifest.Dependencies;
+        //  validate dependency assemblies first - get entry from assembly info
+        foreach (var dep in extDependencies)
         {
             //  get the assembly name only because that is what the AssemblyRegistry uses
-            // Assuming you have a stream that contains the assembly data
-            using (Stream assemblyStream = entry.Open())
+            var depAssembly = dep.Name;
+            if (assemblies.TryResolve(depAssembly.Name, out _))
             {
-                try
-                {
-                    // Get the AssemblyName from the stream
-                    AssemblyName assemblyName = new();
+                //  if we have the dependency registered, then we continue
+                continue;
+            }
 
-                    // Print the name of the assembly
-                    Console.WriteLine($"Assembly Name: {assemblyName.Name}");
-                    Console.WriteLine($"Assembly Version: {assemblyName.Version}");
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"An error occurred: {ex.Message}");
-                }
+            if (TryLoadAssembly(dep, out assembly))
+            {
+                //  register the assembly
+                assemblies.Register(assembly, dep.EntryTag);
             }
         }
+    }
+    /// <summary>
+    /// Register the extension assembly.
+    /// </summary>
+    private void RegisterExtensionAssembly(IAssemblyRegistry assemblies)
+    {
+        Assembly assembly = null;
+        var ext = _manifest.Assembly;
+        var extAssembly = ext.Name;
+
+        //  validate the extension assembly
+        if (assemblies.TryResolve(extAssembly.Name, out _))
+        {
+            //  if we have the extension registered, then we continue ... 
+            //  ... but this should not happen because we are validating the extension
+            Console.WriteLine($"[*** WARNING ***]   Extension {extAssembly.Name} already registered.");
+
+            return;
+        }
+        //  load the extension assembly
+        if (TryLoadAssembly(ext, out assembly))
+        {
+            //  register the extension assembly
+            assemblies.Register(extAssembly, ext.EntryTag);
+        }
+    }
+
+
+    //  load the assembly from the package
+    private bool TryLoadAssembly(AssemblyInfo asmInfo, out Assembly assembly)
+    {
+        var pkgEntry = PkgEntries.FirstOrDefault(a => a.FullName == asmInfo.EntryTag);
+        assembly = null;
+
+        using (Stream asmStream = pkgEntry.Open())
+        {
+            try
+            {
+                using (var memory = new MemoryStream())
+                {
+                    asmStream.CopyTo(memory);
+                    //  load the assembly
+                    assembly = Assembly.Load(memory.ToArray());
+                }
+
+                // Print the name of the assembly
+                Console.WriteLine($"Assembly Name: {assembly.GetName().Name}");
+                Console.WriteLine($"Assembly Version: {assembly.GetName().Version}");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"An error occurred: {ex.Message}");
+            }
+        }
+
+        return assembly != null;
     }
 }

--- a/source/RazorWare.GfxCore.Domain/Facade/GfxApplication.cs
+++ b/source/RazorWare.GfxCore.Domain/Facade/GfxApplication.cs
@@ -27,11 +27,12 @@ public abstract partial class GfxApplication : IRuntime
     /// </summary>
     protected GfxApplication(bool testMode = false)
     {
+        //  load gfx bootstrap
         if ((_bootstrap = GfxBootstrap.Load(testMode, OnBootstrapInitialized)) == null)
         {
             throw new InvalidOperationException("The GfxCore bootstrap failed to load.");
         }
-
+        //  load extensions
         _bootstrap.LoadExtensions();
 
         if (!testMode)

--- a/source/RazorWare.GfxCore.Domain/Runtime/GfxBootstrap.cs
+++ b/source/RazorWare.GfxCore.Domain/Runtime/GfxBootstrap.cs
@@ -95,7 +95,7 @@ internal abstract class GfxBootstrap
     /// </summary>
     internal void LoadExtensions()
     {
-        _loader.DiscoverExtensions();
+        _loader.DiscoverExtensions(out var mods);
     }
 
     /// <summary>

--- a/source/razorware.gfxcore.sln
+++ b/source/razorware.gfxcore.sln
@@ -17,8 +17,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "gfxcore.testing", "testing\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "gfxcore.resources.bar", "dev\GfxCore.Resources.Bar\gfxcore.resources.bar.csproj", "{E6855B33-FA89-4B89-A529-855E35C45838}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "razorware.gfxextension.packager", "RazorWare.GfxExtension.Packager\razorware.gfxextension.packager.csproj", "{3D2DD5F8-BA4A-421F-A056-8AF7892D54CD}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,10 +43,6 @@ Global
 		{E6855B33-FA89-4B89-A529-855E35C45838}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E6855B33-FA89-4B89-A529-855E35C45838}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E6855B33-FA89-4B89-A529-855E35C45838}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3D2DD5F8-BA4A-421F-A056-8AF7892D54CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3D2DD5F8-BA4A-421F-A056-8AF7892D54CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3D2DD5F8-BA4A-421F-A056-8AF7892D54CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3D2DD5F8-BA4A-421F-A056-8AF7892D54CD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
extension info (GfxExtensionInfo) is materialized from zip package.

Manifest class is extracted first from the zip archive package and materialized from the .json content.
All assemblies are verified to be in the package based on the manifest content.
All assemblies are validated against what is already loaded in the application domain or needs to be loaded.
Assemblies are loaded and registered into the AssemblyRegistry.

**AssemblyRegistry** ...
Currently, when you register an `Assembly` it gets the `AssemblyName` and registers that. When you want to later retrieve the `Assembly` we are going to the `AppDomain` to get the assembly. I think we can do a little hocus-focus in the `AssemblyRegistry` to refrain from iterating all domain assemblies every time we want to resolve an `AssemblyName` (which means to retrieve the `Assembly`).